### PR TITLE
Add basic Flask tracker with complete Gen I data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,5 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+data/state.json
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# CatchTracker
+
+A simple local web app to track your progress towards a full living Pokédex while streaming.
+
+## Quick Start
+1. **Install Python 3** (https://www.python.org/downloads/)
+2. **Download or clone this repository**
+3. **Run the app**
+   - Windows: double-click `start.py` or run `python start.py`
+   - macOS/Linux: `python3 start.py`
+
+The script creates a virtual environment, installs required packages, and launches the tracker.
+
+Once running:
+- Open **http://localhost:5000/control** to manage your caught Pokémon.
+- Add **http://localhost:5000/stream** as a browser source in OBS to show the current target.
+
+Progress is saved in `data/state.json`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,97 @@
+import json
+import os
+from flask import Flask, redirect, render_template, request, url_for
+import requests
+
+app = Flask(__name__)
+
+DATA_FILE = os.path.join("data", "games.json")
+STATE_FILE = os.path.join("data", "state.json")
+
+with open(DATA_FILE) as f:
+    GAMES = json.load(f)
+
+def load_state():
+    if os.path.exists(STATE_FILE):
+        with open(STATE_FILE) as f:
+            return json.load(f)
+    # default state
+    generation = next(iter(GAMES.keys()))
+    game = next(iter(GAMES[generation].keys()))
+    return {"generation": generation, "game": game, "index": 0, "caught": {}}
+
+
+def save_state(state):
+    with open(STATE_FILE, "w") as f:
+        json.dump(state, f, indent=2)
+
+
+@app.route("/")
+def index():
+    return redirect(url_for("tracker"))
+
+
+@app.route("/select", methods=["GET", "POST"])
+def select():
+    state = load_state()
+    if request.method == "POST":
+        state["generation"] = request.form["generation"]
+        state["game"] = request.form["game"]
+        state["index"] = 0
+        save_state(state)
+        return redirect(url_for("tracker"))
+    generations = list(GAMES.keys())
+    games_for_gen = GAMES[state["generation"]].keys()
+    return render_template("select.html", generations=generations, games=games_for_gen, state=state)
+
+
+def current_pokemon(state):
+    game_list = GAMES[state["generation"]][state["game"]]
+    if state["index"] < 0:
+        state["index"] = 0
+    if state["index"] >= len(game_list):
+        state["index"] = len(game_list) - 1
+    return game_list[state["index"]]
+
+
+@app.route("/control", methods=["GET", "POST"])
+@app.route("/tracker", methods=["GET", "POST"])
+def tracker():
+    state = load_state()
+    game_list = GAMES[state["generation"]][state["game"]]
+    if request.method == "POST":
+        action = request.form["action"]
+        if action == "next" and state["index"] < len(game_list) - 1:
+            state["index"] += 1
+        elif action == "prev" and state["index"] > 0:
+            state["index"] -= 1
+        elif action == "toggle":
+            poke = current_pokemon(state)["name"]
+            state["caught"][poke] = not state["caught"].get(poke, False)
+        save_state(state)
+    poke = current_pokemon(state)
+    caught = state["caught"].get(poke["name"], False)
+    return render_template("tracker.html", state=state, pokemon=poke, caught=caught)
+
+
+@app.route("/stream")
+@app.route("/display")
+def display():
+    state = load_state()
+    poke = current_pokemon(state)
+    name = poke["name"].lower()
+    # fetch id from pokeapi
+    try:
+        resp = requests.get(f"https://pokeapi.co/api/v2/pokemon/{name}", timeout=5)
+        if resp.ok:
+            poke_id = resp.json()["id"]
+            img_url = f"https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/{poke_id}.png"
+        else:
+            img_url = ""
+    except Exception:
+        img_url = ""
+    return render_template("display.html", pokemon=poke, img_url=img_url)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/data/games.json
+++ b/data/games.json
@@ -1,0 +1,1216 @@
+{
+  "Generation I": {
+    "Red/Blue": [
+      {
+        "name": "Bulbasaur",
+        "location": "Starter"
+      },
+      {
+        "name": "Ivysaur",
+        "location": "Evolve Bulbasaur"
+      },
+      {
+        "name": "Venusaur",
+        "location": "Evolve Ivysaur"
+      },
+      {
+        "name": "Charmander",
+        "location": "Starter"
+      },
+      {
+        "name": "Charmeleon",
+        "location": "Evolve Charmander"
+      },
+      {
+        "name": "Charizard",
+        "location": "Evolve Charmeleon"
+      },
+      {
+        "name": "Squirtle",
+        "location": "Starter"
+      },
+      {
+        "name": "Wartortle",
+        "location": "Evolve Squirtle"
+      },
+      {
+        "name": "Blastoise",
+        "location": "Evolve Wartortle"
+      },
+      {
+        "name": "Caterpie",
+        "location": "Viridian Forest"
+      },
+      {
+        "name": "Metapod",
+        "location": "Viridian Forest"
+      },
+      {
+        "name": "Butterfree",
+        "location": "Evolve Metapod"
+      },
+      {
+        "name": "Weedle",
+        "location": "Viridian Forest"
+      },
+      {
+        "name": "Kakuna",
+        "location": "Viridian Forest"
+      },
+      {
+        "name": "Beedrill",
+        "location": "Evolve Kakuna"
+      },
+      {
+        "name": "Pidgey",
+        "location": "Route 1"
+      },
+      {
+        "name": "Pidgeotto",
+        "location": "Route 17"
+      },
+      {
+        "name": "Pidgeot",
+        "location": "Evolve Pidgeotto"
+      },
+      {
+        "name": "Rattata",
+        "location": "Route 1"
+      },
+      {
+        "name": "Raticate",
+        "location": "Route 16"
+      },
+      {
+        "name": "Spearow",
+        "location": "Route 22"
+      },
+      {
+        "name": "Fearow",
+        "location": "Route 17"
+      },
+      {
+        "name": "Ekans",
+        "location": "Route 4 (Red)"
+      },
+      {
+        "name": "Arbok",
+        "location": "Evolve Ekans"
+      },
+      {
+        "name": "Pikachu",
+        "location": "Viridian Forest"
+      },
+      {
+        "name": "Raichu",
+        "location": "Evolve Pikachu"
+      },
+      {
+        "name": "Sandshrew",
+        "location": "Route 4 (Blue)"
+      },
+      {
+        "name": "Sandslash",
+        "location": "Evolve Sandshrew"
+      },
+      {
+        "name": "Nidoran\u2640",
+        "location": "Route 22"
+      },
+      {
+        "name": "Nidorina",
+        "location": "Evolve Nidoran\u2640"
+      },
+      {
+        "name": "Nidoqueen",
+        "location": "Evolve Nidorina"
+      },
+      {
+        "name": "Nidoran\u2642",
+        "location": "Route 22"
+      },
+      {
+        "name": "Nidorino",
+        "location": "Evolve Nidoran\u2642"
+      },
+      {
+        "name": "Nidoking",
+        "location": "Evolve Nidorino"
+      },
+      {
+        "name": "Clefairy",
+        "location": "Mt. Moon"
+      },
+      {
+        "name": "Clefable",
+        "location": "Evolve Clefairy"
+      },
+      {
+        "name": "Vulpix",
+        "location": "Route 7 (Blue)"
+      },
+      {
+        "name": "Ninetales",
+        "location": "Evolve Vulpix"
+      },
+      {
+        "name": "Jigglypuff",
+        "location": "Route 3"
+      },
+      {
+        "name": "Wigglytuff",
+        "location": "Evolve Jigglypuff"
+      },
+      {
+        "name": "Zubat",
+        "location": "Mt. Moon"
+      },
+      {
+        "name": "Golbat",
+        "location": "Victory Road"
+      },
+      {
+        "name": "Oddish",
+        "location": "Route 24 (Red)"
+      },
+      {
+        "name": "Gloom",
+        "location": "Evolve Oddish"
+      },
+      {
+        "name": "Vileplume",
+        "location": "Evolve Gloom"
+      },
+      {
+        "name": "Paras",
+        "location": "Mt. Moon"
+      },
+      {
+        "name": "Parasect",
+        "location": "Evolve Paras"
+      },
+      {
+        "name": "Venonat",
+        "location": "Route 24"
+      },
+      {
+        "name": "Venomoth",
+        "location": "Evolve Venonat"
+      },
+      {
+        "name": "Diglett",
+        "location": "Diglett's Cave"
+      },
+      {
+        "name": "Dugtrio",
+        "location": "Diglett's Cave"
+      },
+      {
+        "name": "Meowth",
+        "location": "Route 5 (Blue)"
+      },
+      {
+        "name": "Persian",
+        "location": "Evolve Meowth"
+      },
+      {
+        "name": "Psyduck",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Golduck",
+        "location": "Evolve Psyduck"
+      },
+      {
+        "name": "Mankey",
+        "location": "Route 22 (Red)"
+      },
+      {
+        "name": "Primeape",
+        "location": "Evolve Mankey"
+      },
+      {
+        "name": "Growlithe",
+        "location": "Route 7 (Red)"
+      },
+      {
+        "name": "Arcanine",
+        "location": "Evolve Growlithe"
+      },
+      {
+        "name": "Poliwag",
+        "location": "Route 6 (Good Rod)"
+      },
+      {
+        "name": "Poliwhirl",
+        "location": "Evolve Poliwag"
+      },
+      {
+        "name": "Poliwrath",
+        "location": "Evolve Poliwhirl"
+      },
+      {
+        "name": "Abra",
+        "location": "Route 24"
+      },
+      {
+        "name": "Kadabra",
+        "location": "Evolve Abra"
+      },
+      {
+        "name": "Alakazam",
+        "location": "Trade Kadabra"
+      },
+      {
+        "name": "Machop",
+        "location": "Rock Tunnel"
+      },
+      {
+        "name": "Machoke",
+        "location": "Evolve Machop"
+      },
+      {
+        "name": "Machamp",
+        "location": "Trade Machoke"
+      },
+      {
+        "name": "Bellsprout",
+        "location": "Route 24 (Blue)"
+      },
+      {
+        "name": "Weepinbell",
+        "location": "Evolve Bellsprout"
+      },
+      {
+        "name": "Victreebel",
+        "location": "Evolve Weepinbell"
+      },
+      {
+        "name": "Tentacool",
+        "location": "Route 19 (Surf)"
+      },
+      {
+        "name": "Tentacruel",
+        "location": "Evolve Tentacool"
+      },
+      {
+        "name": "Geodude",
+        "location": "Mt. Moon"
+      },
+      {
+        "name": "Graveler",
+        "location": "Evolve Geodude"
+      },
+      {
+        "name": "Golem",
+        "location": "Trade Graveler"
+      },
+      {
+        "name": "Ponyta",
+        "location": "Pokemon Mansion"
+      },
+      {
+        "name": "Rapidash",
+        "location": "Evolve Ponyta"
+      },
+      {
+        "name": "Slowpoke",
+        "location": "Route 12 (Super Rod)"
+      },
+      {
+        "name": "Slowbro",
+        "location": "Evolve Slowpoke"
+      },
+      {
+        "name": "Magnemite",
+        "location": "Power Plant"
+      },
+      {
+        "name": "Magneton",
+        "location": "Power Plant"
+      },
+      {
+        "name": "Farfetch'd",
+        "location": "Vermilion City Trade"
+      },
+      {
+        "name": "Doduo",
+        "location": "Route 16"
+      },
+      {
+        "name": "Dodrio",
+        "location": "Evolve Doduo"
+      },
+      {
+        "name": "Seel",
+        "location": "Seafoam Islands"
+      },
+      {
+        "name": "Dewgong",
+        "location": "Evolve Seel"
+      },
+      {
+        "name": "Grimer",
+        "location": "Pokemon Mansion (Red)"
+      },
+      {
+        "name": "Muk",
+        "location": "Evolve Grimer"
+      },
+      {
+        "name": "Shellder",
+        "location": "Route 19 (Good Rod)"
+      },
+      {
+        "name": "Cloyster",
+        "location": "Evolve Shellder"
+      },
+      {
+        "name": "Gastly",
+        "location": "Pokemon Tower"
+      },
+      {
+        "name": "Haunter",
+        "location": "Pokemon Tower"
+      },
+      {
+        "name": "Gengar",
+        "location": "Trade Haunter"
+      },
+      {
+        "name": "Onix",
+        "location": "Rock Tunnel"
+      },
+      {
+        "name": "Drowzee",
+        "location": "Route 11"
+      },
+      {
+        "name": "Hypno",
+        "location": "Evolve Drowzee"
+      },
+      {
+        "name": "Krabby",
+        "location": "Route 6 (Good Rod)"
+      },
+      {
+        "name": "Kingler",
+        "location": "Evolve Krabby"
+      },
+      {
+        "name": "Voltorb",
+        "location": "Power Plant"
+      },
+      {
+        "name": "Electrode",
+        "location": "Power Plant"
+      },
+      {
+        "name": "Exeggcute",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Exeggutor",
+        "location": "Evolve Exeggcute"
+      },
+      {
+        "name": "Cubone",
+        "location": "Pokemon Tower"
+      },
+      {
+        "name": "Marowak",
+        "location": "Pokemon Tower"
+      },
+      {
+        "name": "Hitmonlee",
+        "location": "Saffron Dojo"
+      },
+      {
+        "name": "Hitmonchan",
+        "location": "Saffron Dojo"
+      },
+      {
+        "name": "Lickitung",
+        "location": "Route 18 Trade"
+      },
+      {
+        "name": "Koffing",
+        "location": "Pokemon Mansion"
+      },
+      {
+        "name": "Weezing",
+        "location": "Evolve Koffing"
+      },
+      {
+        "name": "Rhyhorn",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Rhydon",
+        "location": "Evolve Rhyhorn"
+      },
+      {
+        "name": "Chansey",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Tangela",
+        "location": "Route 21"
+      },
+      {
+        "name": "Kangaskhan",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Horsea",
+        "location": "Route 19 (Good Rod)"
+      },
+      {
+        "name": "Seadra",
+        "location": "Evolve Horsea"
+      },
+      {
+        "name": "Goldeen",
+        "location": "Route 6 (Good Rod)"
+      },
+      {
+        "name": "Seaking",
+        "location": "Evolve Goldeen"
+      },
+      {
+        "name": "Staryu",
+        "location": "Route 19 (Super Rod)"
+      },
+      {
+        "name": "Starmie",
+        "location": "Evolve Staryu"
+      },
+      {
+        "name": "Mr. Mime",
+        "location": "Route 2 Trade"
+      },
+      {
+        "name": "Scyther",
+        "location": "Safari Zone (Red)"
+      },
+      {
+        "name": "Jynx",
+        "location": "Cerulean City Trade"
+      },
+      {
+        "name": "Electabuzz",
+        "location": "Power Plant (Red)"
+      },
+      {
+        "name": "Magmar",
+        "location": "Pokemon Mansion (Blue)"
+      },
+      {
+        "name": "Pinsir",
+        "location": "Safari Zone (Blue)"
+      },
+      {
+        "name": "Tauros",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Magikarp",
+        "location": "Route 4 (Old Rod)"
+      },
+      {
+        "name": "Gyarados",
+        "location": "Evolve Magikarp"
+      },
+      {
+        "name": "Lapras",
+        "location": "Silph Co. Gift"
+      },
+      {
+        "name": "Ditto",
+        "location": "Pokemon Mansion"
+      },
+      {
+        "name": "Eevee",
+        "location": "Celadon City Gift"
+      },
+      {
+        "name": "Vaporeon",
+        "location": "Evolve Eevee"
+      },
+      {
+        "name": "Jolteon",
+        "location": "Evolve Eevee"
+      },
+      {
+        "name": "Flareon",
+        "location": "Evolve Eevee"
+      },
+      {
+        "name": "Porygon",
+        "location": "Celadon Game Corner"
+      },
+      {
+        "name": "Omanyte",
+        "location": "Cinnabar Lab (Helix Fossil)"
+      },
+      {
+        "name": "Omastar",
+        "location": "Evolve Omanyte"
+      },
+      {
+        "name": "Kabuto",
+        "location": "Cinnabar Lab (Dome Fossil)"
+      },
+      {
+        "name": "Kabutops",
+        "location": "Evolve Kabuto"
+      },
+      {
+        "name": "Aerodactyl",
+        "location": "Cinnabar Lab (Old Amber)"
+      },
+      {
+        "name": "Snorlax",
+        "location": "Route 12"
+      },
+      {
+        "name": "Articuno",
+        "location": "Seafoam Islands"
+      },
+      {
+        "name": "Zapdos",
+        "location": "Power Plant"
+      },
+      {
+        "name": "Moltres",
+        "location": "Victory Road"
+      },
+      {
+        "name": "Dratini",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Dragonair",
+        "location": "Evolve Dratini"
+      },
+      {
+        "name": "Dragonite",
+        "location": "Evolve Dragonair"
+      },
+      {
+        "name": "Mewtwo",
+        "location": "Cerulean Cave"
+      },
+      {
+        "name": "Mew",
+        "location": "Event"
+      }
+    ],
+    "Yellow": [
+      {
+        "name": "Pikachu",
+        "location": "Starter"
+      },
+      {
+        "name": "Bulbasaur",
+        "location": "Cerulean City Gift"
+      },
+      {
+        "name": "Charmander",
+        "location": "Route 24 Gift"
+      },
+      {
+        "name": "Squirtle",
+        "location": "Vermilion City Gift"
+      },
+      {
+        "name": "Ivysaur",
+        "location": "Evolve Bulbasaur"
+      },
+      {
+        "name": "Venusaur",
+        "location": "Evolve Ivysaur"
+      },
+      {
+        "name": "Charmeleon",
+        "location": "Evolve Charmander"
+      },
+      {
+        "name": "Charizard",
+        "location": "Evolve Charmeleon"
+      },
+      {
+        "name": "Wartortle",
+        "location": "Evolve Squirtle"
+      },
+      {
+        "name": "Blastoise",
+        "location": "Evolve Wartortle"
+      },
+      {
+        "name": "Caterpie",
+        "location": "Viridian Forest"
+      },
+      {
+        "name": "Metapod",
+        "location": "Viridian Forest"
+      },
+      {
+        "name": "Butterfree",
+        "location": "Evolve Metapod"
+      },
+      {
+        "name": "Weedle",
+        "location": "Viridian Forest"
+      },
+      {
+        "name": "Kakuna",
+        "location": "Viridian Forest"
+      },
+      {
+        "name": "Beedrill",
+        "location": "Evolve Kakuna"
+      },
+      {
+        "name": "Pidgey",
+        "location": "Route 1"
+      },
+      {
+        "name": "Pidgeotto",
+        "location": "Route 17"
+      },
+      {
+        "name": "Pidgeot",
+        "location": "Evolve Pidgeotto"
+      },
+      {
+        "name": "Rattata",
+        "location": "Route 1"
+      },
+      {
+        "name": "Raticate",
+        "location": "Route 16"
+      },
+      {
+        "name": "Spearow",
+        "location": "Route 22"
+      },
+      {
+        "name": "Fearow",
+        "location": "Route 17"
+      },
+      {
+        "name": "Ekans",
+        "location": "Route 4 (Red)"
+      },
+      {
+        "name": "Arbok",
+        "location": "Evolve Ekans"
+      },
+      {
+        "name": "Raichu",
+        "location": "Evolve Pikachu"
+      },
+      {
+        "name": "Sandshrew",
+        "location": "Route 4 (Blue)"
+      },
+      {
+        "name": "Sandslash",
+        "location": "Evolve Sandshrew"
+      },
+      {
+        "name": "Nidoran\u2640",
+        "location": "Route 22"
+      },
+      {
+        "name": "Nidorina",
+        "location": "Evolve Nidoran\u2640"
+      },
+      {
+        "name": "Nidoqueen",
+        "location": "Evolve Nidorina"
+      },
+      {
+        "name": "Nidoran\u2642",
+        "location": "Route 22"
+      },
+      {
+        "name": "Nidorino",
+        "location": "Evolve Nidoran\u2642"
+      },
+      {
+        "name": "Nidoking",
+        "location": "Evolve Nidorino"
+      },
+      {
+        "name": "Clefairy",
+        "location": "Mt. Moon"
+      },
+      {
+        "name": "Clefable",
+        "location": "Evolve Clefairy"
+      },
+      {
+        "name": "Vulpix",
+        "location": "Route 7 (Blue)"
+      },
+      {
+        "name": "Ninetales",
+        "location": "Evolve Vulpix"
+      },
+      {
+        "name": "Jigglypuff",
+        "location": "Route 3"
+      },
+      {
+        "name": "Wigglytuff",
+        "location": "Evolve Jigglypuff"
+      },
+      {
+        "name": "Zubat",
+        "location": "Mt. Moon"
+      },
+      {
+        "name": "Golbat",
+        "location": "Victory Road"
+      },
+      {
+        "name": "Oddish",
+        "location": "Route 24 (Red)"
+      },
+      {
+        "name": "Gloom",
+        "location": "Evolve Oddish"
+      },
+      {
+        "name": "Vileplume",
+        "location": "Evolve Gloom"
+      },
+      {
+        "name": "Paras",
+        "location": "Mt. Moon"
+      },
+      {
+        "name": "Parasect",
+        "location": "Evolve Paras"
+      },
+      {
+        "name": "Venonat",
+        "location": "Route 24"
+      },
+      {
+        "name": "Venomoth",
+        "location": "Evolve Venonat"
+      },
+      {
+        "name": "Diglett",
+        "location": "Diglett's Cave"
+      },
+      {
+        "name": "Dugtrio",
+        "location": "Diglett's Cave"
+      },
+      {
+        "name": "Meowth",
+        "location": "Route 5 (Blue)"
+      },
+      {
+        "name": "Persian",
+        "location": "Evolve Meowth"
+      },
+      {
+        "name": "Psyduck",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Golduck",
+        "location": "Evolve Psyduck"
+      },
+      {
+        "name": "Mankey",
+        "location": "Route 22 (Red)"
+      },
+      {
+        "name": "Primeape",
+        "location": "Evolve Mankey"
+      },
+      {
+        "name": "Growlithe",
+        "location": "Route 7 (Red)"
+      },
+      {
+        "name": "Arcanine",
+        "location": "Evolve Growlithe"
+      },
+      {
+        "name": "Poliwag",
+        "location": "Route 6 (Good Rod)"
+      },
+      {
+        "name": "Poliwhirl",
+        "location": "Evolve Poliwag"
+      },
+      {
+        "name": "Poliwrath",
+        "location": "Evolve Poliwhirl"
+      },
+      {
+        "name": "Abra",
+        "location": "Route 24"
+      },
+      {
+        "name": "Kadabra",
+        "location": "Evolve Abra"
+      },
+      {
+        "name": "Alakazam",
+        "location": "Trade Kadabra"
+      },
+      {
+        "name": "Machop",
+        "location": "Rock Tunnel"
+      },
+      {
+        "name": "Machoke",
+        "location": "Evolve Machop"
+      },
+      {
+        "name": "Machamp",
+        "location": "Trade Machoke"
+      },
+      {
+        "name": "Bellsprout",
+        "location": "Route 24 (Blue)"
+      },
+      {
+        "name": "Weepinbell",
+        "location": "Evolve Bellsprout"
+      },
+      {
+        "name": "Victreebel",
+        "location": "Evolve Weepinbell"
+      },
+      {
+        "name": "Tentacool",
+        "location": "Route 19 (Surf)"
+      },
+      {
+        "name": "Tentacruel",
+        "location": "Evolve Tentacool"
+      },
+      {
+        "name": "Geodude",
+        "location": "Mt. Moon"
+      },
+      {
+        "name": "Graveler",
+        "location": "Evolve Geodude"
+      },
+      {
+        "name": "Golem",
+        "location": "Trade Graveler"
+      },
+      {
+        "name": "Ponyta",
+        "location": "Pokemon Mansion"
+      },
+      {
+        "name": "Rapidash",
+        "location": "Evolve Ponyta"
+      },
+      {
+        "name": "Slowpoke",
+        "location": "Route 12 (Super Rod)"
+      },
+      {
+        "name": "Slowbro",
+        "location": "Evolve Slowpoke"
+      },
+      {
+        "name": "Magnemite",
+        "location": "Power Plant"
+      },
+      {
+        "name": "Magneton",
+        "location": "Power Plant"
+      },
+      {
+        "name": "Farfetch'd",
+        "location": "Vermilion City Trade"
+      },
+      {
+        "name": "Doduo",
+        "location": "Route 16"
+      },
+      {
+        "name": "Dodrio",
+        "location": "Evolve Doduo"
+      },
+      {
+        "name": "Seel",
+        "location": "Seafoam Islands"
+      },
+      {
+        "name": "Dewgong",
+        "location": "Evolve Seel"
+      },
+      {
+        "name": "Grimer",
+        "location": "Pokemon Mansion (Red)"
+      },
+      {
+        "name": "Muk",
+        "location": "Evolve Grimer"
+      },
+      {
+        "name": "Shellder",
+        "location": "Route 19 (Good Rod)"
+      },
+      {
+        "name": "Cloyster",
+        "location": "Evolve Shellder"
+      },
+      {
+        "name": "Gastly",
+        "location": "Pokemon Tower"
+      },
+      {
+        "name": "Haunter",
+        "location": "Pokemon Tower"
+      },
+      {
+        "name": "Gengar",
+        "location": "Trade Haunter"
+      },
+      {
+        "name": "Onix",
+        "location": "Rock Tunnel"
+      },
+      {
+        "name": "Drowzee",
+        "location": "Route 11"
+      },
+      {
+        "name": "Hypno",
+        "location": "Evolve Drowzee"
+      },
+      {
+        "name": "Krabby",
+        "location": "Route 6 (Good Rod)"
+      },
+      {
+        "name": "Kingler",
+        "location": "Evolve Krabby"
+      },
+      {
+        "name": "Voltorb",
+        "location": "Power Plant"
+      },
+      {
+        "name": "Electrode",
+        "location": "Power Plant"
+      },
+      {
+        "name": "Exeggcute",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Exeggutor",
+        "location": "Evolve Exeggcute"
+      },
+      {
+        "name": "Cubone",
+        "location": "Pokemon Tower"
+      },
+      {
+        "name": "Marowak",
+        "location": "Pokemon Tower"
+      },
+      {
+        "name": "Hitmonlee",
+        "location": "Saffron Dojo"
+      },
+      {
+        "name": "Hitmonchan",
+        "location": "Saffron Dojo"
+      },
+      {
+        "name": "Lickitung",
+        "location": "Route 18 Trade"
+      },
+      {
+        "name": "Koffing",
+        "location": "Pokemon Mansion"
+      },
+      {
+        "name": "Weezing",
+        "location": "Evolve Koffing"
+      },
+      {
+        "name": "Rhyhorn",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Rhydon",
+        "location": "Evolve Rhyhorn"
+      },
+      {
+        "name": "Chansey",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Tangela",
+        "location": "Route 21"
+      },
+      {
+        "name": "Kangaskhan",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Horsea",
+        "location": "Route 19 (Good Rod)"
+      },
+      {
+        "name": "Seadra",
+        "location": "Evolve Horsea"
+      },
+      {
+        "name": "Goldeen",
+        "location": "Route 6 (Good Rod)"
+      },
+      {
+        "name": "Seaking",
+        "location": "Evolve Goldeen"
+      },
+      {
+        "name": "Staryu",
+        "location": "Route 19 (Super Rod)"
+      },
+      {
+        "name": "Starmie",
+        "location": "Evolve Staryu"
+      },
+      {
+        "name": "Mr. Mime",
+        "location": "Route 2 Trade"
+      },
+      {
+        "name": "Scyther",
+        "location": "Safari Zone (Red)"
+      },
+      {
+        "name": "Jynx",
+        "location": "Cerulean City Trade"
+      },
+      {
+        "name": "Electabuzz",
+        "location": "Power Plant (Red)"
+      },
+      {
+        "name": "Magmar",
+        "location": "Pokemon Mansion (Blue)"
+      },
+      {
+        "name": "Pinsir",
+        "location": "Safari Zone (Blue)"
+      },
+      {
+        "name": "Tauros",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Magikarp",
+        "location": "Route 4 (Old Rod)"
+      },
+      {
+        "name": "Gyarados",
+        "location": "Evolve Magikarp"
+      },
+      {
+        "name": "Lapras",
+        "location": "Silph Co. Gift"
+      },
+      {
+        "name": "Ditto",
+        "location": "Pokemon Mansion"
+      },
+      {
+        "name": "Eevee",
+        "location": "Celadon City Gift"
+      },
+      {
+        "name": "Vaporeon",
+        "location": "Evolve Eevee"
+      },
+      {
+        "name": "Jolteon",
+        "location": "Evolve Eevee"
+      },
+      {
+        "name": "Flareon",
+        "location": "Evolve Eevee"
+      },
+      {
+        "name": "Porygon",
+        "location": "Celadon Game Corner"
+      },
+      {
+        "name": "Omanyte",
+        "location": "Cinnabar Lab (Helix Fossil)"
+      },
+      {
+        "name": "Omastar",
+        "location": "Evolve Omanyte"
+      },
+      {
+        "name": "Kabuto",
+        "location": "Cinnabar Lab (Dome Fossil)"
+      },
+      {
+        "name": "Kabutops",
+        "location": "Evolve Kabuto"
+      },
+      {
+        "name": "Aerodactyl",
+        "location": "Cinnabar Lab (Old Amber)"
+      },
+      {
+        "name": "Snorlax",
+        "location": "Route 12"
+      },
+      {
+        "name": "Articuno",
+        "location": "Seafoam Islands"
+      },
+      {
+        "name": "Zapdos",
+        "location": "Power Plant"
+      },
+      {
+        "name": "Moltres",
+        "location": "Victory Road"
+      },
+      {
+        "name": "Dratini",
+        "location": "Safari Zone"
+      },
+      {
+        "name": "Dragonair",
+        "location": "Evolve Dratini"
+      },
+      {
+        "name": "Dragonite",
+        "location": "Evolve Dragonair"
+      },
+      {
+        "name": "Mewtwo",
+        "location": "Cerulean Cave"
+      },
+      {
+        "name": "Mew",
+        "location": "Event"
+      }
+    ]
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests

--- a/start.py
+++ b/start.py
@@ -1,0 +1,17 @@
+import os
+import subprocess
+import sys
+
+VENV_DIR = '.venv'
+
+
+def venv_python(*parts):
+    folder = 'Scripts' if os.name == 'nt' else 'bin'
+    return os.path.join(VENV_DIR, folder, *parts)
+
+
+if not os.path.isdir(VENV_DIR):
+    subprocess.check_call([sys.executable, '-m', 'venv', VENV_DIR])
+    subprocess.check_call([venv_python('pip'), 'install', '-r', 'requirements.txt'])
+
+subprocess.check_call([venv_python('python'), 'app.py'])

--- a/templates/display.html
+++ b/templates/display.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>body{margin:0;background:transparent;text-align:center}</style>
+  </head>
+  <body>
+    {% if img_url %}
+    <img src="{{ img_url }}" alt="{{ pokemon.name }}">
+    {% endif %}
+  </body>
+</html>

--- a/templates/select.html
+++ b/templates/select.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>Select Game</title>
+<h1>Select Generation and Game</h1>
+<form method="post">
+  <label>Generation:
+    <select name="generation">
+      {% for gen in generations %}
+      <option value="{{ gen }}" {% if gen == state.generation %}selected{% endif %}>{{ gen }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <label>Game:
+    <select name="game">
+      {% for game in games %}
+      <option value="{{ game }}" {% if game == state.game %}selected{% endif %}>{{ game }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <button type="submit">Start</button>
+</form>

--- a/templates/tracker.html
+++ b/templates/tracker.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<title>Tracker</title>
+<h1>{{ state.generation }} - {{ state.game }}</h1>
+<p>Current: {{ pokemon.name }} ({{ pokemon.location }})</p>
+<p>Status: {% if caught %}Caught{% else %}Not caught{% endif %}</p>
+<form method="post">
+  <button name="action" value="prev">Prev</button>
+  <button name="action" value="toggle">{% if caught %}Unmark{% else %}Mark Caught{% endif %}</button>
+  <button name="action" value="next">Next</button>
+</form>
+<p><a href="{{ url_for('select') }}">Change game</a></p>
+<p><a href="{{ url_for('display') }}" target="_blank">Open stream view</a></p>


### PR DESCRIPTION
## Summary
- set up Flask app with routes for game selection, tracking caught Pokémon, and external display
- persist progress locally and show current Pokémon sprite
- provide full Generation I data for Red/Blue and Yellow
- add easy `start.py` script and quick start docs for streamers
- add root redirect plus `/control` and `/stream` pages for tracker handling and OBS display

## Testing
- `python -m py_compile app.py start.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4a4cae90c832d822568dd07faa5ef