### PR TITLE
Open tracker automatically and improve styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 import json
 import os
+import threading
+import webbrowser
 from flask import Flask, redirect, render_template, request, url_for
 import requests
 
@@ -87,4 +89,12 @@ def display():
 
 
 if __name__ == "__main__":
+    def open_browser():
+        try:
+            webbrowser.open_new("http://127.0.0.1:5000/tracker")
+            webbrowser.open_new("http://127.0.0.1:5000/display")
+        except Exception:
+            pass
+
+    threading.Timer(1.0, open_browser).start()
     app.run(debug=True)

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,32 @@
+body {
+    font-family: Arial, sans-serif;
+    max-width: 600px;
+    margin: 40px auto;
+    padding: 20px;
+    background-color: #f4f4f4;
+    color: #333;
+    text-align: center;
+}
+
+h1 {
+    margin-bottom: 20px;
+}
+
+form {
+    margin-top: 20px;
+}
+
+button, select {
+    padding: 8px 12px;
+    font-size: 1rem;
+    margin: 0 5px;
+}
+
+a {
+    color: #007bff;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}

--- a/templates/display.html
+++ b/templates/display.html
@@ -1,8 +1,15 @@
 <!doctype html>
-<title>Display</title>
-<h1>{{ pokemon.name }}</h1>
-{% if img_url %}
-<img src="{{ img_url }}" alt="{{ pokemon.name }}">
-{% else %}
-<p>No image available.</p>
-{% endif %}
+<html>
+  <head>
+    <title>Display</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  </head>
+  <body>
+    <h1>{{ pokemon.name }}</h1>
+    {% if img_url %}
+    <img src="{{ img_url }}" alt="{{ pokemon.name }}">
+    {% else %}
+    <p>No image available.</p>
+    {% endif %}
+  </body>
+</html>

--- a/templates/select.html
+++ b/templates/select.html
@@ -1,20 +1,27 @@
 <!doctype html>
-<title>Select Game</title>
-<h1>Select Generation and Game</h1>
-<form method="post">
-  <label>Generation:
-    <select name="generation">
-      {% for gen in generations %}
-      <option value="{{ gen }}" {% if gen == state.generation %}selected{% endif %}>{{ gen }}</option>
-      {% endfor %}
-    </select>
-  </label>
-  <label>Game:
-    <select name="game">
-      {% for game in games %}
-      <option value="{{ game }}" {% if game == state.game %}selected{% endif %}>{{ game }}</option>
-      {% endfor %}
-    </select>
-  </label>
-  <button type="submit">Start</button>
-</form>
+<html>
+  <head>
+    <title>Select Game</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  </head>
+  <body>
+    <h1>Select Generation and Game</h1>
+    <form method="post">
+      <label>Generation:
+        <select name="generation">
+          {% for gen in generations %}
+          <option value="{{ gen }}" {% if gen == state.generation %}selected{% endif %}>{{ gen }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>Game:
+        <select name="game">
+          {% for game in games %}
+          <option value="{{ game }}" {% if game == state.game %}selected{% endif %}>{{ game }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <button type="submit">Start</button>
+    </form>
+  </body>
+</html>

--- a/templates/tracker.html
+++ b/templates/tracker.html
@@ -1,12 +1,19 @@
 <!doctype html>
-<title>Tracker</title>
-<h1>{{ state.generation }} - {{ state.game }}</h1>
-<p>Current: {{ pokemon.name }} ({{ pokemon.location }})</p>
-<p>Status: {% if caught %}Caught{% else %}Not caught{% endif %}</p>
-<form method="post">
-  <button name="action" value="prev">Prev</button>
-  <button name="action" value="toggle">{% if caught %}Unmark{% else %}Mark Caught{% endif %}</button>
-  <button name="action" value="next">Next</button>
-</form>
-<p><a href="{{ url_for('select') }}">Change game</a></p>
-<p><a href="{{ url_for('display') }}" target="_blank">Open display</a></p>
+<html>
+  <head>
+    <title>Tracker</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  </head>
+  <body>
+    <h1>{{ state.generation }} - {{ state.game }}</h1>
+    <p>Current: <strong>{{ pokemon.name }}</strong> ({{ pokemon.location }})</p>
+    <p>Status: {% if caught %}Caught{% else %}Not caught{% endif %}</p>
+    <form method="post">
+      <button name="action" value="prev">Prev</button>
+      <button name="action" value="toggle">{% if caught %}Unmark{% else %}Mark Caught{% endif %}</button>
+      <button name="action" value="next">Next</button>
+    </form>
+    <p><a href="{{ url_for('select') }}">Change game</a></p>
+    <p><a href="{{ url_for('display') }}" target="_blank">Open display</a></p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Launch tracker and display pages in browser on startup
- Add shared stylesheet and apply basic styling to templates

## Testing
- `python -m py_compile app.py start.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b646ad70832da051062c630d3bba