### PR TITLE
Add dark mode and auto-refresh to tracker display

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,38 @@
+body {
+    font-family: Arial, sans-serif;
+    max-width: 600px;
+    margin: 40px auto;
+    padding: 20px;
+    background-color: var(--bg-color, #f4f4f4);
+    color: var(--text-color, #333);
+    text-align: center;
+}
+
+h1 {
+    margin-bottom: 20px;
+}
+
+form {
+    margin-top: 20px;
+}
+
+button, select {
+    padding: 8px 12px;
+    font-size: 1rem;
+    margin: 0 5px;
+}
+
+a {
+    color: var(--link-color, #007bff);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+body.dark-mode {
+    --bg-color: #121212;
+    --text-color: #eee;
+    --link-color: #4da3ff;
+}

--- a/static/theme.js
+++ b/static/theme.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const btn = document.getElementById('theme-toggle');
+  if (!btn) return;
+  let theme = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  function applyTheme() {
+    document.body.classList.toggle('dark-mode', theme === 'dark');
+    btn.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+  }
+  btn.addEventListener('click', () => {
+    theme = theme === 'dark' ? 'light' : 'dark';
+    localStorage.setItem('theme', theme);
+    applyTheme();
+  });
+  applyTheme();
+});

--- a/templates/display.html
+++ b/templates/display.html
@@ -1,8 +1,27 @@
 <!doctype html>
-<title>Display</title>
-<h1>{{ pokemon.name }}</h1>
-{% if img_url %}
-<img src="{{ img_url }}" alt="{{ pokemon.name }}">
-{% else %}
-<p>No image available.</p>
-{% endif %}
+<html>
+  <head>
+    <title>Display</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  </head>
+  <body>
+    <h1>{{ pokemon.name }}</h1>
+    <button id="theme-toggle"></button>
+    {% if img_url %}
+    <img src="{{ img_url }}" alt="{{ pokemon.name }}">
+    {% else %}
+    <p>No image available.</p>
+    {% endif %}
+    <script src="{{ url_for('static', filename='theme.js') }}"></script>
+    <script>
+      let currentIndex = {{ index }};
+      setInterval(function () {
+        fetch("{{ url_for('current_index') }}").then(r => r.json()).then(data => {
+          if (data.index !== currentIndex) {
+            location.reload();
+          }
+        });
+      }, 2000);
+    </script>
+  </body>
+</html>

--- a/templates/select.html
+++ b/templates/select.html
@@ -1,20 +1,29 @@
 <!doctype html>
-<title>Select Game</title>
-<h1>Select Generation and Game</h1>
-<form method="post">
-  <label>Generation:
-    <select name="generation">
-      {% for gen in generations %}
-      <option value="{{ gen }}" {% if gen == state.generation %}selected{% endif %}>{{ gen }}</option>
-      {% endfor %}
-    </select>
-  </label>
-  <label>Game:
-    <select name="game">
-      {% for game in games %}
-      <option value="{{ game }}" {% if game == state.game %}selected{% endif %}>{{ game }}</option>
-      {% endfor %}
-    </select>
-  </label>
-  <button type="submit">Start</button>
-</form>
+<html>
+  <head>
+    <title>Select Game</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  </head>
+  <body>
+    <h1>Select Generation and Game</h1>
+    <button id="theme-toggle"></button>
+    <form method="post">
+      <label>Generation:
+        <select name="generation">
+          {% for gen in generations %}
+          <option value="{{ gen }}" {% if gen == state.generation %}selected{% endif %}>{{ gen }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>Game:
+        <select name="game">
+          {% for game in games %}
+          <option value="{{ game }}" {% if game == state.game %}selected{% endif %}>{{ game }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <button type="submit">Start</button>
+    </form>
+    <script src="{{ url_for('static', filename='theme.js') }}"></script>
+  </body>
+</html>

--- a/templates/tracker.html
+++ b/templates/tracker.html
@@ -1,12 +1,21 @@
 <!doctype html>
-<title>Tracker</title>
-<h1>{{ state.generation }} - {{ state.game }}</h1>
-<p>Current: {{ pokemon.name }} ({{ pokemon.location }})</p>
-<p>Status: {% if caught %}Caught{% else %}Not caught{% endif %}</p>
-<form method="post">
-  <button name="action" value="prev">Prev</button>
-  <button name="action" value="toggle">{% if caught %}Unmark{% else %}Mark Caught{% endif %}</button>
-  <button name="action" value="next">Next</button>
-</form>
-<p><a href="{{ url_for('select') }}">Change game</a></p>
-<p><a href="{{ url_for('display') }}" target="_blank">Open display</a></p>
+<html>
+  <head>
+    <title>Tracker</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  </head>
+  <body>
+    <h1>{{ state.generation }} - {{ state.game }}</h1>
+    <button id="theme-toggle"></button>
+    <p>Current: <strong>{{ pokemon.name }}</strong> ({{ pokemon.location }})</p>
+    <p>Status: {% if caught %}Caught{% else %}Not caught{% endif %}</p>
+    <form method="post">
+      <button name="action" value="prev">Prev</button>
+      <button name="action" value="toggle">{% if caught %}Unmark{% else %}Mark Caught{% endif %}</button>
+      <button name="action" value="next">Next</button>
+    </form>
+    <p><a href="{{ url_for('select') }}">Change game</a></p>
+    <p><a href="{{ url_for('display') }}" target="_blank">Open display</a></p>
+    <script src="{{ url_for('static', filename='theme.js') }}"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Launch tracker and display pages in browser on startup
- Add shared stylesheet and apply basic styling to templates
- Add dark mode theme with toggle across pages
- Auto-refresh display when current Pokémon changes
- Sort Pokémon list by catchable order

## Testing
- `python -m py_compile app.py start.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b646ad70832da051062c630d3bba