### PR TITLE
Add dex list with sprites and search bar

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -8,6 +8,13 @@ body {
     text-align: center;
 }
 
+body.transparent {
+    background-color: transparent;
+    margin: 0;
+    max-width: none;
+    padding: 0;
+}
+
 h1 {
     margin-bottom: 20px;
 }
@@ -16,7 +23,7 @@ form {
     margin-top: 20px;
 }
 
-button, select {
+button, select, input {
     padding: 8px 12px;
     font-size: 1rem;
     margin: 0 5px;
@@ -35,4 +42,30 @@ body.dark-mode {
     --bg-color: #121212;
     --text-color: #eee;
     --link-color: #4da3ff;
+}
+
+#dex-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+#dex-table th,
+#dex-table td {
+    border: 1px solid #ccc;
+    padding: 4px;
+    text-align: center;
+}
+
+#dex-table img {
+    display: block;
+    margin: 0 auto;
+}
+
+#dex-table tr.caught {
+    opacity: 0.5;
+}
+
+#dex-table tr.current {
+    outline: 2px solid red;
 }

--- a/templates/display.html
+++ b/templates/display.html
@@ -4,15 +4,12 @@
     <title>Display</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
-  <body>
-    <h1>{{ pokemon.name }}</h1>
-    <button id="theme-toggle"></button>
+  <body class="transparent">
     {% if img_url %}
     <img src="{{ img_url }}" alt="{{ pokemon.name }}">
     {% else %}
     <p>No image available.</p>
     {% endif %}
-    <script src="{{ url_for('static', filename='theme.js') }}"></script>
     <script>
       let currentIndex = {{ index }};
       setInterval(function () {

--- a/templates/tracker.html
+++ b/templates/tracker.html
@@ -16,6 +16,41 @@
     </form>
     <p><a href="{{ url_for('select') }}">Change game</a></p>
     <p><a href="{{ url_for('display') }}" target="_blank">Open display</a></p>
+    <input type="text" id="search" placeholder="Search Pokémon">
+    <table id="dex-table">
+      <thead>
+        <tr>
+          <th>DexID</th>
+          <th>Sprite</th>
+          <th>Name</th>
+          <th>Generation(s)</th>
+          <th>Game(s)</th>
+          <th>Location</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for p in dex_list %}
+        <tr data-name="{{ p.name | lower }}" class="{% if p.id == pokemon.id %}current{% endif %}{% if caught_map.get(p.id|string)%} caught{% endif %}">
+          <td>{{ '%03d'|format(p.id) }}</td>
+          <td>{% if p.img_url %}<img src="{{ p.img_url }}" alt="{{ p.name }}">{% endif %}</td>
+          <td>{{ p.name }}</td>
+          <td>{{ ', '.join(p.generations) }}</td>
+          <td>{{ ', '.join(p.games) }}</td>
+          <td>{{ p.locations.get(state.game, '') }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
     <script src="{{ url_for('static', filename='theme.js') }}"></script>
+    <script>
+      const search = document.getElementById('search');
+      search.addEventListener('input', function () {
+        const term = this.value.toLowerCase();
+        document.querySelectorAll('#dex-table tbody tr').forEach(tr => {
+          tr.style.display = tr.dataset.name.includes(term) ? '' : 'none';
+        });
+      });
+    </script>
   </body>
 </html>
+


### PR DESCRIPTION
## Summary
- aggregate Pokémon data across generations to include dex IDs, games, and per-game locations
- show a searchable dex table with sprites and highlight current or caught Pokémon by dex number
- track caught status by dex ID so progress persists across games

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4bb995264832db4626d133b4f6f44