### PR TITLE
Add Generation II locations and refine generation display

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A simple local web app to track your progress towards a full living Pokédex while streaming.
 
+Current data includes Generation I (Red/Blue, Yellow) and Generation II (Gold/Silver, Crystal) games.
+
 ## Quick Start
 1. **Install Python 3** (https://www.python.org/downloads/)
 2. **Download or clone this repository**

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ STATE_FILE = os.path.join("data", "state.json")
 
 with open(DATA_FILE) as f:
     GAMES = json.load(f)
+KNOWN_GAMES = {g for games in GAMES.values() for combo in games.keys() for g in combo.split("/")}
 
 POKE_CACHE_FILE = os.path.join("data", "pokemon_cache.json")
 if os.path.exists(POKE_CACHE_FILE):
@@ -54,8 +55,12 @@ def get_poke_info(name):
 def parse_location(loc_str):
     match = re.match(r"^(.*?)(?:\s*\(([^)]+)\))?$", loc_str)
     base = match.group(1).strip()
-    variants = [v.strip() for v in match.group(2).split("/")] if match.group(2) else []
-    return base, variants
+    variant_str = match.group(2)
+    if variant_str:
+        variants = [v.strip() for v in variant_str.split("/")]
+        if all(v in KNOWN_GAMES for v in variants):
+            return base, variants
+    return loc_str.strip(), []
 
 
 def game_entries_for_state(state):
@@ -66,7 +71,7 @@ def game_entries_for_state(state):
     return []
 
 
-def full_dex_list():
+def full_dex_list(filter_gen=None):
     all_poke = {}
     for gen, games in GAMES.items():
         for combo, entries in games.items():
@@ -95,6 +100,8 @@ def full_dex_list():
     for p in all_poke.values():
         p["generations"] = sorted(p["generations"])
         p["games"] = sorted(p["games"])
+        if filter_gen and filter_gen not in p["generations"]:
+            continue
         dex.append(p)
     return sorted(dex, key=lambda x: x["id"])
 
@@ -172,7 +179,7 @@ def current_pokemon(state, game_list=None):
 def tracker():
     state = load_state()
     game_list = ordered_game_list(state)
-    dex_list = full_dex_list()
+    dex_list = full_dex_list(state["generation"])
     if request.method == "POST":
         action = request.form["action"]
         if action == "next" and state["index"] < len(game_list) - 1:

--- a/data/games.json
+++ b/data/games.json
@@ -1212,5 +1212,811 @@
         "location": "Event"
       }
     ]
+  },
+  "Generation II": {
+    "Gold/Silver": [
+      {
+        "name": "Chikorita",
+        "location": "Starter"
+      },
+      {
+        "name": "Bayleef",
+        "location": "Evolve Chikorita"
+      },
+      {
+        "name": "Meganium",
+        "location": "Evolve Bayleef"
+      },
+      {
+        "name": "Cyndaquil",
+        "location": "Starter"
+      },
+      {
+        "name": "Quilava",
+        "location": "Evolve Cyndaquil"
+      },
+      {
+        "name": "Typhlosion",
+        "location": "Evolve Quilava"
+      },
+      {
+        "name": "Totodile",
+        "location": "Starter"
+      },
+      {
+        "name": "Croconaw",
+        "location": "Evolve Totodile"
+      },
+      {
+        "name": "Feraligatr",
+        "location": "Evolve Croconaw"
+      },
+      {
+        "name": "Sentret",
+        "location": "Route 29"
+      },
+      {
+        "name": "Furret",
+        "location": "Evolve Sentret"
+      },
+      {
+        "name": "Hoothoot",
+        "location": "Route 29"
+      },
+      {
+        "name": "Noctowl",
+        "location": "Evolve Hoothoot"
+      },
+      {
+        "name": "Ledyba",
+        "location": "Route 30 (Gold)"
+      },
+      {
+        "name": "Ledian",
+        "location": "Evolve Ledyba"
+      },
+      {
+        "name": "Spinarak",
+        "location": "Route 30 (Silver)"
+      },
+      {
+        "name": "Ariados",
+        "location": "Evolve Spinarak"
+      },
+      {
+        "name": "Crobat",
+        "location": "Evolve Golbat"
+      },
+      {
+        "name": "Chinchou",
+        "location": "Route 20"
+      },
+      {
+        "name": "Lanturn",
+        "location": "Evolve Chinchou"
+      },
+      {
+        "name": "Pichu",
+        "location": "Breed Pikachu"
+      },
+      {
+        "name": "Cleffa",
+        "location": "Mt. Moon"
+      },
+      {
+        "name": "Igglybuff",
+        "location": "Breed Jigglypuff"
+      },
+      {
+        "name": "Togepi",
+        "location": "Elm's Egg"
+      },
+      {
+        "name": "Togetic",
+        "location": "Evolve Togepi"
+      },
+      {
+        "name": "Natu",
+        "location": "Ruins of Alph"
+      },
+      {
+        "name": "Xatu",
+        "location": "Evolve Natu"
+      },
+      {
+        "name": "Mareep",
+        "location": "Route 32"
+      },
+      {
+        "name": "Flaaffy",
+        "location": "Evolve Mareep"
+      },
+      {
+        "name": "Ampharos",
+        "location": "Evolve Flaaffy"
+      },
+      {
+        "name": "Bellossom",
+        "location": "Use Sun Stone"
+      },
+      {
+        "name": "Marill",
+        "location": "Ilex Forest"
+      },
+      {
+        "name": "Azumarill",
+        "location": "Evolve Marill"
+      },
+      {
+        "name": "Sudowoodo",
+        "location": "Route 36"
+      },
+      {
+        "name": "Politoed",
+        "location": "Trade Poliwhirl"
+      },
+      {
+        "name": "Hoppip",
+        "location": "Route 32"
+      },
+      {
+        "name": "Skiploom",
+        "location": "Evolve Hoppip"
+      },
+      {
+        "name": "Jumpluff",
+        "location": "Evolve Skiploom"
+      },
+      {
+        "name": "Aipom",
+        "location": "Azalea Town"
+      },
+      {
+        "name": "Sunkern",
+        "location": "National Park"
+      },
+      {
+        "name": "Sunflora",
+        "location": "Evolve Sunkern"
+      },
+      {
+        "name": "Yanma",
+        "location": "Route 35"
+      },
+      {
+        "name": "Wooper",
+        "location": "Route 32"
+      },
+      {
+        "name": "Quagsire",
+        "location": "Evolve Wooper"
+      },
+      {
+        "name": "Espeon",
+        "location": "Evolve Eevee"
+      },
+      {
+        "name": "Umbreon",
+        "location": "Evolve Eevee"
+      },
+      {
+        "name": "Murkrow",
+        "location": "Route 7 (Gold)"
+      },
+      {
+        "name": "Slowking",
+        "location": "Trade Slowpoke"
+      },
+      {
+        "name": "Misdreavus",
+        "location": "Mt. Silver (Silver)"
+      },
+      {
+        "name": "Unown",
+        "location": "Ruins of Alph"
+      },
+      {
+        "name": "Wobbuffet",
+        "location": "Dark Cave"
+      },
+      {
+        "name": "Girafarig",
+        "location": "Route 43"
+      },
+      {
+        "name": "Pineco",
+        "location": "Ilex Forest"
+      },
+      {
+        "name": "Forretress",
+        "location": "Evolve Pineco"
+      },
+      {
+        "name": "Dunsparce",
+        "location": "Dark Cave"
+      },
+      {
+        "name": "Gligar",
+        "location": "Route 45 (Gold)"
+      },
+      {
+        "name": "Steelix",
+        "location": "Trade Onix"
+      },
+      {
+        "name": "Snubbull",
+        "location": "Route 38"
+      },
+      {
+        "name": "Granbull",
+        "location": "Evolve Snubbull"
+      },
+      {
+        "name": "Qwilfish",
+        "location": "Route 32"
+      },
+      {
+        "name": "Scizor",
+        "location": "Trade Scyther"
+      },
+      {
+        "name": "Shuckle",
+        "location": "Cianwood City"
+      },
+      {
+        "name": "Heracross",
+        "location": "Azalea Town"
+      },
+      {
+        "name": "Sneasel",
+        "location": "Ice Path (Silver)"
+      },
+      {
+        "name": "Teddiursa",
+        "location": "Route 45 (Silver)"
+      },
+      {
+        "name": "Ursaring",
+        "location": "Evolve Teddiursa"
+      },
+      {
+        "name": "Slugma",
+        "location": "Route 16"
+      },
+      {
+        "name": "Magcargo",
+        "location": "Evolve Slugma"
+      },
+      {
+        "name": "Swinub",
+        "location": "Ice Path"
+      },
+      {
+        "name": "Piloswine",
+        "location": "Evolve Swinub"
+      },
+      {
+        "name": "Corsola",
+        "location": "Route 34"
+      },
+      {
+        "name": "Remoraid",
+        "location": "Route 44"
+      },
+      {
+        "name": "Octillery",
+        "location": "Evolve Remoraid"
+      },
+      {
+        "name": "Delibird",
+        "location": "Ice Path"
+      },
+      {
+        "name": "Mantine",
+        "location": "Route 41"
+      },
+      {
+        "name": "Skarmory",
+        "location": "Route 45 (Silver)"
+      },
+      {
+        "name": "Houndour",
+        "location": "Route 7 (Silver)"
+      },
+      {
+        "name": "Houndoom",
+        "location": "Evolve Houndour"
+      },
+      {
+        "name": "Kingdra",
+        "location": "Trade Seadra"
+      },
+      {
+        "name": "Phanpy",
+        "location": "Route 45 (Gold)"
+      },
+      {
+        "name": "Donphan",
+        "location": "Evolve Phanpy"
+      },
+      {
+        "name": "Porygon2",
+        "location": "Trade Porygon"
+      },
+      {
+        "name": "Stantler",
+        "location": "Route 37"
+      },
+      {
+        "name": "Smeargle",
+        "location": "Ruins of Alph"
+      },
+      {
+        "name": "Tyrogue",
+        "location": "Mt. Mortar"
+      },
+      {
+        "name": "Hitmontop",
+        "location": "Evolve Tyrogue"
+      },
+      {
+        "name": "Smoochum",
+        "location": "Breed Jynx"
+      },
+      {
+        "name": "Elekid",
+        "location": "Breed Electabuzz"
+      },
+      {
+        "name": "Magby",
+        "location": "Breed Magmar"
+      },
+      {
+        "name": "Miltank",
+        "location": "Route 38"
+      },
+      {
+        "name": "Blissey",
+        "location": "Evolve Chansey"
+      },
+      {
+        "name": "Raikou",
+        "location": "Roaming Johto"
+      },
+      {
+        "name": "Entei",
+        "location": "Roaming Johto"
+      },
+      {
+        "name": "Suicune",
+        "location": "Roaming Johto"
+      },
+      {
+        "name": "Larvitar",
+        "location": "Mt. Silver"
+      },
+      {
+        "name": "Pupitar",
+        "location": "Evolve Larvitar"
+      },
+      {
+        "name": "Tyranitar",
+        "location": "Evolve Pupitar"
+      },
+      {
+        "name": "Lugia",
+        "location": "Whirl Islands"
+      },
+      {
+        "name": "Ho-Oh",
+        "location": "Tin Tower"
+      },
+      {
+        "name": "Celebi",
+        "location": "Ilex Forest Shrine"
+      }
+    ],
+    "Crystal": [
+      {
+        "name": "Chikorita",
+        "location": "Starter"
+      },
+      {
+        "name": "Bayleef",
+        "location": "Evolve Chikorita"
+      },
+      {
+        "name": "Meganium",
+        "location": "Evolve Bayleef"
+      },
+      {
+        "name": "Cyndaquil",
+        "location": "Starter"
+      },
+      {
+        "name": "Quilava",
+        "location": "Evolve Cyndaquil"
+      },
+      {
+        "name": "Typhlosion",
+        "location": "Evolve Quilava"
+      },
+      {
+        "name": "Totodile",
+        "location": "Starter"
+      },
+      {
+        "name": "Croconaw",
+        "location": "Evolve Totodile"
+      },
+      {
+        "name": "Feraligatr",
+        "location": "Evolve Croconaw"
+      },
+      {
+        "name": "Sentret",
+        "location": "Route 29"
+      },
+      {
+        "name": "Furret",
+        "location": "Evolve Sentret"
+      },
+      {
+        "name": "Hoothoot",
+        "location": "Route 29"
+      },
+      {
+        "name": "Noctowl",
+        "location": "Evolve Hoothoot"
+      },
+      {
+        "name": "Ledyba",
+        "location": "Route 30"
+      },
+      {
+        "name": "Ledian",
+        "location": "Evolve Ledyba"
+      },
+      {
+        "name": "Spinarak",
+        "location": "Route 30"
+      },
+      {
+        "name": "Ariados",
+        "location": "Evolve Spinarak"
+      },
+      {
+        "name": "Crobat",
+        "location": "Evolve Golbat"
+      },
+      {
+        "name": "Chinchou",
+        "location": "Route 20"
+      },
+      {
+        "name": "Lanturn",
+        "location": "Evolve Chinchou"
+      },
+      {
+        "name": "Pichu",
+        "location": "Breed Pikachu"
+      },
+      {
+        "name": "Cleffa",
+        "location": "Mt. Moon"
+      },
+      {
+        "name": "Igglybuff",
+        "location": "Breed Jigglypuff"
+      },
+      {
+        "name": "Togepi",
+        "location": "Elm's Egg"
+      },
+      {
+        "name": "Togetic",
+        "location": "Evolve Togepi"
+      },
+      {
+        "name": "Natu",
+        "location": "Ruins of Alph"
+      },
+      {
+        "name": "Xatu",
+        "location": "Evolve Natu"
+      },
+      {
+        "name": "Mareep",
+        "location": "Route 42"
+      },
+      {
+        "name": "Flaaffy",
+        "location": "Evolve Mareep"
+      },
+      {
+        "name": "Ampharos",
+        "location": "Evolve Flaaffy"
+      },
+      {
+        "name": "Bellossom",
+        "location": "Use Sun Stone"
+      },
+      {
+        "name": "Marill",
+        "location": "Ilex Forest"
+      },
+      {
+        "name": "Azumarill",
+        "location": "Evolve Marill"
+      },
+      {
+        "name": "Sudowoodo",
+        "location": "Route 36"
+      },
+      {
+        "name": "Politoed",
+        "location": "Trade Poliwhirl"
+      },
+      {
+        "name": "Hoppip",
+        "location": "Route 32"
+      },
+      {
+        "name": "Skiploom",
+        "location": "Evolve Hoppip"
+      },
+      {
+        "name": "Jumpluff",
+        "location": "Evolve Skiploom"
+      },
+      {
+        "name": "Aipom",
+        "location": "Azalea Town"
+      },
+      {
+        "name": "Sunkern",
+        "location": "National Park"
+      },
+      {
+        "name": "Sunflora",
+        "location": "Evolve Sunkern"
+      },
+      {
+        "name": "Yanma",
+        "location": "Route 35"
+      },
+      {
+        "name": "Wooper",
+        "location": "Route 32"
+      },
+      {
+        "name": "Quagsire",
+        "location": "Evolve Wooper"
+      },
+      {
+        "name": "Espeon",
+        "location": "Evolve Eevee"
+      },
+      {
+        "name": "Umbreon",
+        "location": "Evolve Eevee"
+      },
+      {
+        "name": "Murkrow",
+        "location": "Route 7"
+      },
+      {
+        "name": "Slowking",
+        "location": "Trade Slowpoke"
+      },
+      {
+        "name": "Misdreavus",
+        "location": "Mt. Silver"
+      },
+      {
+        "name": "Unown",
+        "location": "Ruins of Alph"
+      },
+      {
+        "name": "Wobbuffet",
+        "location": "Dark Cave"
+      },
+      {
+        "name": "Girafarig",
+        "location": "Route 43"
+      },
+      {
+        "name": "Pineco",
+        "location": "Ilex Forest"
+      },
+      {
+        "name": "Forretress",
+        "location": "Evolve Pineco"
+      },
+      {
+        "name": "Dunsparce",
+        "location": "Dark Cave"
+      },
+      {
+        "name": "Gligar",
+        "location": "Route 45"
+      },
+      {
+        "name": "Steelix",
+        "location": "Trade Onix"
+      },
+      {
+        "name": "Snubbull",
+        "location": "Route 38"
+      },
+      {
+        "name": "Granbull",
+        "location": "Evolve Snubbull"
+      },
+      {
+        "name": "Qwilfish",
+        "location": "Route 32"
+      },
+      {
+        "name": "Scizor",
+        "location": "Trade Scyther"
+      },
+      {
+        "name": "Shuckle",
+        "location": "Cianwood City"
+      },
+      {
+        "name": "Heracross",
+        "location": "Azalea Town"
+      },
+      {
+        "name": "Sneasel",
+        "location": "Ice Path"
+      },
+      {
+        "name": "Teddiursa",
+        "location": "Route 45"
+      },
+      {
+        "name": "Ursaring",
+        "location": "Evolve Teddiursa"
+      },
+      {
+        "name": "Slugma",
+        "location": "Route 16"
+      },
+      {
+        "name": "Magcargo",
+        "location": "Evolve Slugma"
+      },
+      {
+        "name": "Swinub",
+        "location": "Ice Path"
+      },
+      {
+        "name": "Piloswine",
+        "location": "Evolve Swinub"
+      },
+      {
+        "name": "Corsola",
+        "location": "Route 34"
+      },
+      {
+        "name": "Remoraid",
+        "location": "Route 44"
+      },
+      {
+        "name": "Octillery",
+        "location": "Evolve Remoraid"
+      },
+      {
+        "name": "Delibird",
+        "location": "Ice Path"
+      },
+      {
+        "name": "Mantine",
+        "location": "Route 41"
+      },
+      {
+        "name": "Skarmory",
+        "location": "Route 45"
+      },
+      {
+        "name": "Houndour",
+        "location": "Route 7"
+      },
+      {
+        "name": "Houndoom",
+        "location": "Evolve Houndour"
+      },
+      {
+        "name": "Kingdra",
+        "location": "Trade Seadra"
+      },
+      {
+        "name": "Phanpy",
+        "location": "Route 45"
+      },
+      {
+        "name": "Donphan",
+        "location": "Evolve Phanpy"
+      },
+      {
+        "name": "Porygon2",
+        "location": "Trade Porygon"
+      },
+      {
+        "name": "Stantler",
+        "location": "Route 37"
+      },
+      {
+        "name": "Smeargle",
+        "location": "Ruins of Alph"
+      },
+      {
+        "name": "Tyrogue",
+        "location": "Mt. Mortar"
+      },
+      {
+        "name": "Hitmontop",
+        "location": "Evolve Tyrogue"
+      },
+      {
+        "name": "Smoochum",
+        "location": "Breed Jynx"
+      },
+      {
+        "name": "Elekid",
+        "location": "Breed Electabuzz"
+      },
+      {
+        "name": "Magby",
+        "location": "Breed Magmar"
+      },
+      {
+        "name": "Miltank",
+        "location": "Route 38"
+      },
+      {
+        "name": "Blissey",
+        "location": "Evolve Chansey"
+      },
+      {
+        "name": "Raikou",
+        "location": "Roaming Johto"
+      },
+      {
+        "name": "Entei",
+        "location": "Roaming Johto"
+      },
+      {
+        "name": "Suicune",
+        "location": "Tin Tower"
+      },
+      {
+        "name": "Larvitar",
+        "location": "Mt. Silver"
+      },
+      {
+        "name": "Pupitar",
+        "location": "Evolve Larvitar"
+      },
+      {
+        "name": "Tyranitar",
+        "location": "Evolve Pupitar"
+      },
+      {
+        "name": "Lugia",
+        "location": "Whirl Islands"
+      },
+      {
+        "name": "Ho-Oh",
+        "location": "Tin Tower"
+      },
+      {
+        "name": "Celebi",
+        "location": "Ilex Forest Shrine"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Fill Gold/Silver and Crystal data with full Generation II Pokémon locations
- Filter Pokédex list to selected generation and ignore non-game tags like "Super Rod"

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4bf3d19a8832da9b182a260ea0fb0