### PR TITLE
Split tracker list into uncaught and caught sections with sorting

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -69,3 +69,12 @@ body.dark-mode {
 #dex-table tr.current {
     outline: 2px solid red;
 }
+
+#dex-table tr.section {
+    background-color: #ddd;
+    font-weight: bold;
+}
+
+#dex-table tr.section th {
+    text-align: left;
+}

--- a/templates/tracker.html
+++ b/templates/tracker.html
@@ -10,6 +10,7 @@
     <p>Current: <strong>{{ pokemon.name }}</strong> ({{ pokemon.location }})</p>
     <p>Status: {% if caught %}Caught{% else %}Not caught{% endif %}</p>
     <form method="post">
+      <input type="hidden" name="sort" value="{{ sort }}">
       <button name="action" value="prev">Prev</button>
       <button name="action" value="toggle">{% if caught %}Unmark{% else %}Mark Caught{% endif %}</button>
       <button name="action" value="next">Next</button>
@@ -17,6 +18,13 @@
     <p><a href="{{ url_for('select') }}">Change game</a></p>
     <p><a href="{{ url_for('display') }}" target="_blank">Open display</a></p>
     <input type="text" id="search" placeholder="Search Pokémon">
+    <form method="get" id="sort-form">
+      <label for="sort">Sort:</label>
+      <select name="sort" id="sort" onchange="this.form.submit()">
+        <option value="catch" {% if sort == 'catch' %}selected{% endif %}>Catch Order</option>
+        <option value="dex" {% if sort == 'dex' %}selected{% endif %}>Dex Order</option>
+      </select>
+    </form>
     <table id="dex-table">
       <thead>
         <tr>
@@ -29,8 +37,20 @@
         </tr>
       </thead>
       <tbody>
-        {% for p in dex_list %}
-        <tr data-name="{{ p.name | lower }}" class="{% if p.id == pokemon.id %}current{% endif %}{% if caught_map.get(p.id|string)%} caught{% endif %}">
+        <tr class="section"><th colspan="6">Uncaught</th></tr>
+        {% for p in uncaught_list %}
+        <tr data-name="{{ p.name | lower }}" class="{% if p.id == pokemon.id %}current{% endif %}">
+          <td>{{ '%03d'|format(p.id) }}</td>
+          <td>{% if p.img_url %}<img src="{{ p.img_url }}" alt="{{ p.name }}">{% endif %}</td>
+          <td>{{ p.name }}</td>
+          <td>{{ ', '.join(p.generations) }}</td>
+          <td>{{ ', '.join(p.games) }}</td>
+          <td>{{ p.locations.get(state.game, '') }}</td>
+        </tr>
+        {% endfor %}
+        <tr class="section"><th colspan="6">Caught</th></tr>
+        {% for p in caught_list %}
+        <tr data-name="{{ p.name | lower }}" class="caught{% if p.id == pokemon.id %} current{% endif %}">
           <td>{{ '%03d'|format(p.id) }}</td>
           <td>{% if p.img_url %}<img src="{{ p.img_url }}" alt="{{ p.name }}">{% endif %}</td>
           <td>{{ p.name }}</td>
@@ -47,6 +67,7 @@
       search.addEventListener('input', function () {
         const term = this.value.toLowerCase();
         document.querySelectorAll('#dex-table tbody tr').forEach(tr => {
+          if (tr.classList.contains('section')) return;
           tr.style.display = tr.dataset.name.includes(term) ? '' : 'none';
         });
       });


### PR DESCRIPTION
## Summary
- Divide tracker list into distinct Uncaught and Caught sections
- Allow sorting by Catch Order or Dex Order and preserve selection on navigation
- Style and JavaScript updates for new sections and sorting controls

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4c5547ef8832db397ba770c573511