### PR TITLE
Enable selecting Pokémon from tracker list

### DIFF
--- a/app.py
+++ b/app.py
@@ -221,6 +221,20 @@ def tracker():
     )
 
 
+@app.route("/set_current", methods=["POST"])
+def set_current():
+    data = request.get_json()
+    poke_id = int(data.get("id", -1))
+    state = load_state()
+    game_list = ordered_game_list(state)
+    for i, p in enumerate(game_list):
+        if p["id"] == poke_id:
+            state["index"] = i
+            save_state(state)
+            break
+    return "", 204
+
+
 @app.route("/display")
 def display():
     state = load_state()

--- a/static/style.css
+++ b/static/style.css
@@ -78,3 +78,7 @@ body.dark-mode {
 #dex-table tr.section th {
     text-align: left;
 }
+
+#dex-table tbody tr:not(.section) {
+    cursor: pointer;
+}

--- a/templates/tracker.html
+++ b/templates/tracker.html
@@ -39,7 +39,7 @@
       <tbody>
         <tr class="section"><th colspan="6">Uncaught</th></tr>
         {% for p in uncaught_list %}
-        <tr data-name="{{ p.name | lower }}" class="{% if p.id == pokemon.id %}current{% endif %}">
+        <tr data-name="{{ p.name | lower }}" data-id="{{ p.id }}" class="{% if p.id == pokemon.id %}current{% endif %}">
           <td>{{ '%03d'|format(p.id) }}</td>
           <td>{% if p.img_url %}<img src="{{ p.img_url }}" alt="{{ p.name }}">{% endif %}</td>
           <td>{{ p.name }}</td>
@@ -50,7 +50,7 @@
         {% endfor %}
         <tr class="section"><th colspan="6">Caught</th></tr>
         {% for p in caught_list %}
-        <tr data-name="{{ p.name | lower }}" class="caught{% if p.id == pokemon.id %} current{% endif %}">
+        <tr data-name="{{ p.name | lower }}" data-id="{{ p.id }}" class="caught{% if p.id == pokemon.id %} current{% endif %}">
           <td>{{ '%03d'|format(p.id) }}</td>
           <td>{% if p.img_url %}<img src="{{ p.img_url }}" alt="{{ p.name }}">{% endif %}</td>
           <td>{{ p.name }}</td>
@@ -69,6 +69,17 @@
         document.querySelectorAll('#dex-table tbody tr').forEach(tr => {
           if (tr.classList.contains('section')) return;
           tr.style.display = tr.dataset.name.includes(term) ? '' : 'none';
+        });
+      });
+      document.querySelectorAll('#dex-table tbody tr').forEach(tr => {
+        if (tr.classList.contains('section')) return;
+        tr.addEventListener('click', function () {
+          const id = this.dataset.id;
+          fetch("{{ url_for('set_current') }}", {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({id: id})
+          }).then(() => location.reload());
         });
       });
     </script>


### PR DESCRIPTION
## Summary
- Allow selecting Pokémon directly from tracker list
- Update display when list entry is clicked
- Indicate clickable rows in tracker table

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68bae8eb3a08832d9cd630137c5b62af