### PR TITLE
Add adjustable title and generation count to display

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -15,6 +15,10 @@ body.transparent {
     padding: 0;
 }
 
+#title, #count {
+    color: white;
+}
+
 h1 {
     margin-bottom: 20px;
 }

--- a/templates/display.html
+++ b/templates/display.html
@@ -5,16 +5,25 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
   <body class="transparent">
+    <div id="title" style="font-size: {{ title_size }}px;">
+      Currently Hunting<br>{{ pokemon.name }}
+    </div>
     {% if img_url %}
     <img src="{{ img_url }}" alt="{{ pokemon.name }}">
     {% else %}
     <p>No image available.</p>
     {% endif %}
+    <div id="count" style="font-size: {{ title_size }}px;">
+      {{ caught_count }}/{{ total_count }}
+    </div>
     <script>
       let currentIndex = {{ index }};
+      let currentTitleSize = {{ title_size }};
+      let currentCaught = {{ caught_count }};
+      let currentTotal = {{ total_count }};
       setInterval(function () {
         fetch("{{ url_for('current_index') }}").then(r => r.json()).then(data => {
-          if (data.index !== currentIndex) {
+          if (data.index !== currentIndex || data.title_size !== currentTitleSize || data.caught_count !== currentCaught || data.total_count !== currentTotal) {
             location.reload();
           }
         });

--- a/templates/tracker.html
+++ b/templates/tracker.html
@@ -17,6 +17,11 @@
     </form>
     <p><a href="{{ url_for('select') }}">Change game</a></p>
     <p><a href="{{ url_for('display') }}" target="_blank">Open display</a></p>
+    <div>
+      <label for="title-size">Title Size:</label>
+      <input type="range" id="title-size" min="10" max="100" value="{{ state.title_size }}">
+      <span id="title-size-value">{{ state.title_size }}</span>px
+    </div>
     <input type="text" id="search" placeholder="Search Pokémon">
     <form method="get" id="sort-form">
       <label for="sort">Sort:</label>
@@ -69,6 +74,18 @@
         document.querySelectorAll('#dex-table tbody tr').forEach(tr => {
           if (tr.classList.contains('section')) return;
           tr.style.display = tr.dataset.name.includes(term) ? '' : 'none';
+        });
+      });
+      const titleSizeInput = document.getElementById('title-size');
+      const titleSizeValue = document.getElementById('title-size-value');
+      titleSizeInput.addEventListener('input', function () {
+        titleSizeValue.textContent = this.value;
+      });
+      titleSizeInput.addEventListener('change', function () {
+        fetch("{{ url_for('set_title_size') }}", {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({size: this.value})
         });
       });
       document.querySelectorAll('#dex-table tbody tr').forEach(tr => {


### PR DESCRIPTION
## Summary
- Store `title_size` in state and expose route to update it
- Show "Currently Hunting" title and caught/total counts on display
- Add slider on tracker page to adjust display title size

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bf0542014c832dba64c222617188c4